### PR TITLE
Update haskell-gi-base.cabal

### DIFF
--- a/haskell-gi-base.cabal
+++ b/haskell-gi-base.cabal
@@ -56,5 +56,6 @@ library
     ghc-options: -Wall -fwarn-incomplete-patterns
 
   build-tools:         hsc2hs
+  cc-options:          -fPIC
   extensions:          CPP, ForeignFunctionInterface, DoAndIfThenElse
   c-sources:           src/c/hsgclosure.c


### PR DESCRIPTION
Error on ubuntu 16.10 without this line "cc-options: -fPIC"